### PR TITLE
Add xpidl plugin to mozilla-central tree.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -33,6 +33,9 @@ defaults:
       name: 'bugzilla'
       url: 'https://bugzilla.mozilla.org/show_bug.cgi?id=%s'
       regex: '"(?i)bug\s+#?([0-9]+)"'
+    - plugin: 'xpidl'
+      header_bucket: 'src/mozilla-central/obj-x86_64-unknown-linux/dist/include'
+      include_folders: 'src/mozilla-central/obj-x86_64-unknown-linux/dist/idl'
 
 trees:
   - name: 'mozilla-central'
@@ -42,16 +45,6 @@ trees:
     job_weight: 4
     ignore_patterns: 'all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc'
     build_command: 'cd $source_folder && ./mach mercurial-setup -u && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"'
-    dxr_plugins:
-      - plugin: 'python'
-        python_path: '/builds/dxr-build-env/venv/lib/python2.7/site-packages'
-      - plugin: 'buglink'
-        name: 'bugzilla'
-        url: 'https://bugzilla.mozilla.org/show_bug.cgi?id=%s'
-        regex: '"(?i)bug\s+#?([0-9]+)"'
-      - plugin: 'xpidl'
-        header_bucket: 'src/mozilla-central/obj-x86_64-unknown-linux/dist/include'
-        include_folders: 'src/mozilla-central/obj-x86_64-unknown-linux/dist/idl'
     mozconfig:
       - 'mk_add_options AUTOCLOBBER=1'
       - 'ac_add_options --enable-debug'

--- a/config.yml
+++ b/config.yml
@@ -42,6 +42,16 @@ trees:
     job_weight: 4
     ignore_patterns: 'all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc'
     build_command: 'cd $source_folder && ./mach mercurial-setup -u && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"'
+    dxr_plugins:
+      - plugin: 'python'
+        python_path: '/builds/dxr-build-env/venv/lib/python2.7/site-packages'
+      - plugin: 'buglink'
+        name: 'bugzilla'
+        url: 'https://bugzilla.mozilla.org/show_bug.cgi?id=%s'
+        regex: '"(?i)bug\s+#?([0-9]+)"'
+      - plugin: 'xpidl'
+        header_bucket: 'src/mozilla-central/obj-x86_64-unknown-linux/dist/include'
+        include_folders: 'src/mozilla-central/obj-x86_64-unknown-linux/dist/idl'
     mozconfig:
       - 'mk_add_options AUTOCLOBBER=1'
       - 'ac_add_options --enable-debug'

--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,7 @@ dxr:
   www_root: '/'
   workers: 4
   default_tree: 'mozilla-central'
-  disabled_plugins: 'xpidl'
+  disabled_plugins: ''
   enabled_plugins: '*'
   es_hosts:
     - http://node47.bunker.scl3.mozilla.com:9200/

--- a/dxr.config
+++ b/dxr.config
@@ -24,6 +24,9 @@ build_command = cd $source_folder && ./mach mercurial-setup -u && make -f client
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [comm-central]
 source_folder = src/comm-central

--- a/dxr.config
+++ b/dxr.config
@@ -2,7 +2,7 @@
 www_root = /
 workers = 4
 default_tree = mozilla-central
-disabled_plugins = xpidl
+disabled_plugins = 
 enabled_plugins = *
 es_hosts = http://node47.bunker.scl3.mozilla.com:9200/ http://node48.bunker.scl3.mozilla.com:9200/ http://node49.bunker.scl3.mozilla.com:9200/
 es_catalog_replicas = 4

--- a/dxr.config
+++ b/dxr.config
@@ -39,6 +39,9 @@ build_command = cd $source_folder && python client.py checkout && make -f client
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build-central]
 source_folder = src/build
@@ -50,6 +53,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [hgcustom_version-control-tools]
 source_folder = src/hgcustom/version-control-tools
@@ -61,6 +67,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [rust]
 source_folder = src/rust-lang/rust
@@ -72,6 +81,9 @@ build_command = cd $source_folder && ./configure --disable-libcpp --enable-ccach
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_ash-mozharness]
 source_folder = src/build/ash-mozharness
@@ -83,6 +95,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_autoland]
 source_folder = src/build/autoland
@@ -94,6 +109,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_braindump]
 source_folder = src/build/braindump
@@ -105,6 +123,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_buildapi]
 source_folder = src/build/buildapi
@@ -116,6 +137,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_buildbot]
 source_folder = src/build/buildbot
@@ -127,6 +151,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_buildbot-configs]
 source_folder = src/build/buildbot-configs
@@ -138,6 +165,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_buildbotcustom]
 source_folder = src/build/buildbotcustom
@@ -149,6 +179,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_cloud-tools]
 source_folder = src/build/cloud-tools
@@ -160,6 +193,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_compare-locales]
 source_folder = src/build/compare-locales
@@ -171,6 +207,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_mozharness]
 source_folder = src/build/mozharness
@@ -182,6 +221,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_mozpool]
 source_folder = src/build/mozpool
@@ -193,6 +235,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_nagios-tools]
 source_folder = src/build/nagios-tools
@@ -204,6 +249,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_opsi-package-sources]
 source_folder = src/build/opsi-package-sources
@@ -215,6 +263,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_partner-repacks]
 source_folder = src/build/partner-repacks
@@ -226,6 +277,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_preproduction]
 source_folder = src/build/preproduction
@@ -237,6 +291,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_puppet]
 source_folder = src/build/puppet
@@ -248,6 +305,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_puppet-manifests]
 source_folder = src/build/puppet-manifests
@@ -259,6 +319,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_relabs-puppet]
 source_folder = src/build/relabs-puppet
@@ -270,6 +333,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_relengapi]
 source_folder = src/build/relengapi
@@ -281,6 +347,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_rpm-sources]
 source_folder = src/build/rpm-sources
@@ -292,6 +361,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_serves3]
 source_folder = src/build/serveS3
@@ -303,6 +375,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_slaveapi]
 source_folder = src/build/slaveapi
@@ -314,6 +389,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_slave_health]
 source_folder = src/build/slave_health
@@ -325,6 +403,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_talos]
 source_folder = src/build/talos
@@ -337,6 +418,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_tools]
 source_folder = src/build/tools
@@ -348,6 +432,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_tupperware]
 source_folder = src/build/tupperware
@@ -359,6 +446,9 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 
 [build_twisted]
 source_folder = src/build/twisted
@@ -370,4 +460,7 @@ build_command =
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
     regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
+  [[xpidl]]
+    include_folders = src/mozilla-central/obj-x86_64-unknown-linux/dist/idl
+    header_bucket = src/mozilla-central/obj-x86_64-unknown-linux/dist/include
 


### PR DESCRIPTION
We've landed the xpidl plugin! Let's enable it for mozilla-central.
