### PR TITLE
Remove explicit buglink plugin regexes.

### DIFF
--- a/dxr.config
+++ b/dxr.config
@@ -23,7 +23,6 @@ build_command = cd $source_folder && ./mach mercurial-setup -u && ./mach clobber
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
   [[buglink]]
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
-    regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
 
 [comm-central]
@@ -36,7 +35,6 @@ build_command = cd $source_folder && python client.py checkout && ./mozilla/mach
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
   [[buglink]]
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
-    regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
 
 [build-central]
@@ -48,7 +46,6 @@ build_command =
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
   [[buglink]]
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
-    regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
 
 [hgcustom_version-control-tools]
@@ -59,7 +56,6 @@ build_command =
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
   [[buglink]]
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
-    regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
 
 [rust]
@@ -72,7 +68,6 @@ build_command = cd $source_folder && ./configure --disable-libcpp --enable-ccach
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
   [[buglink]]
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
-    regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
 
 [nss]
@@ -83,6 +78,5 @@ build_command = cd $source_folder/nss && make nss_build_all
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
   [[buglink]]
     url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
-    regex = "(?i)bug\s+#?([0-9]+)"
     name = bugzilla
 


### PR DESCRIPTION
There's something wrong with quoted regexes in the config parser (https://bugzilla.mozilla.org/show_bug.cgi?id=1212597). In the meantime, let's just fall back to the default, which (1) is parsed correctly and (2) is identical to this pattern.
