### PR TITLE
Let `make` create the virtualenv.

### DIFF
--- a/docker/ubuntu-indexer/bin/dxr-setup.sh
+++ b/docker/ubuntu-indexer/bin/dxr-setup.sh
@@ -33,7 +33,6 @@ git clone --recursive https://github.com/mozilla/dxr && \
     (cd dxr && git checkout $REV)
 
 #export PATH=/usr/lib/llvm-3.5/bin/:${PATH}
-virtualenv venv
 env VIRTUAL_ENV=`pwd`/venv CC=clang CXX=clang++ make -C dxr
 
 # Remove this script


### PR DESCRIPTION
There's no sense repeating ourselves. make will see VIRTUAL_ENV, notice there's no actual venv there, and create it.
