### PR TITLE
Remove duplicated plugin configuration

### DIFF
--- a/dxr.config
+++ b/dxr.config
@@ -134,9 +134,6 @@ build_command = cd $source_folder && ./configure --disable-libcpp --enable-ccach
     name = github
   [[python]]
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
-  [[buglink]]
-    url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
-    name = bugzilla
 
 [rustfmt]
 source_folder = src/rustfmt
@@ -149,9 +146,6 @@ build_command = cd $source_folder/src && RUSTC=/builds/dxr-build-env/dxr/dxr/plu
     name = github
   [[python]]
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
-  [[buglink]]
-    url = https://bugzilla.mozilla.org/show_bug.cgi?id=%s
-    name = bugzilla
 
 [nss]
 source_folder = src/nss

--- a/lib/update_config.py
+++ b/lib/update_config.py
@@ -153,7 +153,9 @@ def main():
         t['object_folder'] = os.path.join('obj', t['proj_dir'])
         t['source_folder'] = os.path.join('src', t['proj_dir'])
         # merge default plugin conf with this one
-        t['plugins'].extend(cfg['defaults']['dxr_plugins'])
+        plugin_keys = [conf['plugin'] for conf in t['plugins']]
+        t['plugins'].extend([conf for conf in cfg['defaults']['dxr_plugins']
+                             if conf['plugin'] not in plugin_keys])
 
         # merge dicts, with tree dict taking precedence
         trees.append(dict(cfg['defaults'], **t))


### PR DESCRIPTION
I overlooked in the last patch that plugin configuration would be duplicated if it was presented in both the tree and the default sections.
This commit fixes it, and I did make sure to run it through the config parser to make sure.
