### PR TITLE
Re-enable js and fix path for xpidl

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,7 @@ dxr:
   www_root: '/'
   workers: 4
   default_tree: 'mozilla-central'
-  disabled_plugins: 'xpidl js'
+  disabled_plugins: 'xpidl'
   enabled_plugins: '*'
   es_hosts:
     - http://node47.bunker.scl3.mozilla.com:9200/
@@ -50,8 +50,8 @@ trees:
       - 'ac_add_options --enable-default-toolkit=cairo-gtk3'
     plugins:
       - plugin: 'xpidl'
-        header_path: 'src/mozilla-central/obj-x86_64-unknown-linux-gnu/dist/include'
-        include_folders: 'src/mozilla-central/obj-x86_64-unknown-linux-gnu/dist/idl'
+        header_path: 'src/mozilla-central/obj-x86_64-pc-linux-gnu/dist/include'
+        include_folders: 'src/mozilla-central/obj-x86_64-pc-linux-gnu/dist/idl'
 
   - name: 'mozilla-aurora'
     proj_dir: 'releases'

--- a/dxr.config
+++ b/dxr.config
@@ -2,7 +2,7 @@
 www_root = /
 workers = 4
 default_tree = mozilla-central
-disabled_plugins = xpidl js
+disabled_plugins = xpidl
 enabled_plugins = *
 es_hosts = http://node47.bunker.scl3.mozilla.com:9200/ http://node48.bunker.scl3.mozilla.com:9200/ http://node49.bunker.scl3.mozilla.com:9200/
 es_catalog_replicas = 4
@@ -20,8 +20,8 @@ es_index = dxr_hot_{format}_{tree}_{unique}
 ignore_patterns = all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder && ./mach mercurial-setup -u && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"
   [[xpidl]]
-    header_path = src/mozilla-central/obj-x86_64-unknown-linux-gnu/dist/include
-    include_folders = src/mozilla-central/obj-x86_64-unknown-linux-gnu/dist/idl
+    header_path = src/mozilla-central/obj-x86_64-pc-linux-gnu/dist/include
+    include_folders = src/mozilla-central/obj-x86_64-pc-linux-gnu/dist/idl
   [[python]]
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
   [[buglink]]


### PR DESCRIPTION
Looks like the builds become more stable now, so we could give js another shot (and fix the path for xpidl on mozilla-central).
