### PR TITLE
Enable xpidl, fix path on mozilla-aurora

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -43,6 +43,7 @@ trees:
     es_index: 'dxr_hot_{format}_{tree}_{unique}'
     ignore_patterns: 'all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc'
     build_command: 'cd $source_folder && ./mach mercurial-setup -u && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"'
+    disabled_plugins: ' '
     mozconfig:
       - 'mk_add_options AUTOCLOBBER=1'
       - 'ac_add_options --enable-debug'
@@ -62,6 +63,7 @@ trees:
     job_weight: 4
     ignore_patterns: 'all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc'
     build_command: 'cd $source_folder && ./mach mercurial-setup -u && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"'
+    disabled_plugins: ' '
     mozconfig:
       - 'mk_add_options AUTOCLOBBER=1'
       - 'ac_add_options --enable-debug'
@@ -69,8 +71,8 @@ trees:
       - 'ac_add_options --enable-default-toolkit=cairo-gtk3'
     plugins:
       - plugin: 'xpidl'
-        header_path: 'src/releases/mozilla-aurora/obj-x86_64-unknown-linux-gnu/dist/include'
-        include_folders: 'src/releases/mozilla-aurora/obj-x86_64-unknown-linux-gnu/dist/idl'
+        header_path: 'src/releases/mozilla-aurora/obj-x86_64-pc-linux-gnu/dist/include'
+        include_folders: 'src/releases/mozilla-aurora/obj-x86_64-pc-linux-gnu/dist/idl'
 
   - name: 'mozilla-beta'
     proj_dir: 'releases'

--- a/dxr.config
+++ b/dxr.config
@@ -17,6 +17,7 @@ es_refresh_interval = 30
 source_folder = src/mozilla-central
 object_folder = obj/mozilla-central
 es_index = dxr_hot_{format}_{tree}_{unique}
+disabled_plugins =  
 ignore_patterns = all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder && ./mach mercurial-setup -u && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"
   [[xpidl]]
@@ -31,11 +32,12 @@ build_command = cd $source_folder && ./mach mercurial-setup -u && ./mach clobber
 [mozilla-aurora]
 source_folder = src/releases/mozilla-aurora
 object_folder = obj/releases/mozilla-aurora
+disabled_plugins =  
 ignore_patterns = all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder && ./mach mercurial-setup -u && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"
   [[xpidl]]
-    header_path = src/releases/mozilla-aurora/obj-x86_64-unknown-linux-gnu/dist/include
-    include_folders = src/releases/mozilla-aurora/obj-x86_64-unknown-linux-gnu/dist/idl
+    header_path = src/releases/mozilla-aurora/obj-x86_64-pc-linux-gnu/dist/include
+    include_folders = src/releases/mozilla-aurora/obj-x86_64-pc-linux-gnu/dist/idl
   [[python]]
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
   [[buglink]]


### PR DESCRIPTION
With indexing time down to 2 hours I don't foresee any problems from enabling xpidl for a couple of the trees.

Now that aurora is building I could see the path wasn't what I expected from a year ago, so I updated it.
