### PR TITLE
Enable xpidl on mozilla-central by fixing config mistakes.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,6 @@ dxr:
   www_root: '/'
   workers: 4
   default_tree: 'mozilla-central'
-  disabled_plugins: 'xpidl'
   enabled_plugins: '*'
   es_hosts:
     - http://node47.bunker.scl3.mozilla.com:9200/
@@ -43,7 +42,6 @@ trees:
     es_index: 'dxr_hot_{format}_{tree}_{unique}'
     ignore_patterns: 'all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc'
     build_command: 'cd $source_folder && ./mach mercurial-setup -u && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"'
-    disabled_plugins: ' '
     mozconfig:
       - 'mk_add_options AUTOCLOBBER=1'
       - 'ac_add_options --enable-debug'
@@ -63,7 +61,6 @@ trees:
     job_weight: 4
     ignore_patterns: 'all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc'
     build_command: 'cd $source_folder && ./mach mercurial-setup -u && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"'
-    disabled_plugins: ' '
     mozconfig:
       - 'mk_add_options AUTOCLOBBER=1'
       - 'ac_add_options --enable-debug'
@@ -75,6 +72,7 @@ trees:
         include_folders: 'src/releases/mozilla-aurora/obj-x86_64-pc-linux-gnu/dist/idl'
 
   - name: 'mozilla-beta'
+    disabled_plugins: 'xpidl'
     proj_dir: 'releases'
     repos:
       - url: 'https://hg.mozilla.org/releases/mozilla-beta'
@@ -94,6 +92,7 @@ trees:
         include_folders: 'src/releases/mozilla-beta/obj-x86_64-unknown-linux-gnu/dist/idl'
 
   - name: 'mozilla-release'
+    disabled_plugins: 'xpidl'
     proj_dir: 'releases'
     repos:
       - url: 'https://hg.mozilla.org/releases/mozilla-release'
@@ -113,6 +112,7 @@ trees:
         include_folders: 'src/releases/mozilla-release/obj-x86_64-unknown-linux-gnu/dist/idl'
 
   - name: 'mozilla-esr45'
+    disabled_plugins: 'xpidl'
     proj_dir: 'releases'
     repos:
       - url: 'https://hg.mozilla.org/releases/mozilla-esr45'
@@ -132,6 +132,7 @@ trees:
         include_folders: 'src/releases/mozilla-esr45/obj-x86_64-unknown-linux-gnu/dist/idl'
 
   - name: 'comm-central'
+    disabled_plugins: 'xpidl'
     repos:
       - url: 'https://hg.mozilla.org/comm-central'
     schedule: 'H H/6 * * *'
@@ -150,6 +151,7 @@ trees:
       - 'ac_add_options --enable-default-toolkit=cairo-gtk3'
 
   - name: 'build-central'
+    disabled_plugins: 'xpidl'
     proj_dir: 'build'
     job_weight: 2
     build_command: ''
@@ -180,11 +182,13 @@ trees:
       - url: 'https://hg.mozilla.org/build/twisted'
 
   - name: 'hgcustom_version-control-tools'
+    disabled_plugins: 'xpidl'
     proj_dir: 'hgcustom'
     repos:
       - url: 'https://hg.mozilla.org/hgcustom/version-control-tools'
 
   - name: 'rust'
+    disabled_plugins: 'xpidl'
     proj_dir: 'rust-lang'
     repos:
       - url: 'https://github.com/rust-lang/rust.git'
@@ -202,6 +206,7 @@ trees:
         regex: '#([0-9]+)'
 
   - name: 'rustfmt'
+    disabled_plugins: 'xpidl'
     repos:
       - url: 'https://github.com/rust-lang-nursery/rustfmt.git'
     enabled_plugins: 'pygmentize rust buglink'
@@ -214,6 +219,7 @@ trees:
         regex: '#([0-9]+)'
 
   - name: 'nss'
+    disabled_plugins: 'xpidl'
     proj_dir: 'nss'
     repos:
       - url: 'https://hg.mozilla.org/projects/nss'

--- a/dxr.config
+++ b/dxr.config
@@ -2,7 +2,7 @@
 www_root = /
 workers = 4
 default_tree = mozilla-central
-disabled_plugins = xpidl
+disabled_plugins = 
 enabled_plugins = *
 es_hosts = http://node47.bunker.scl3.mozilla.com:9200/ http://node48.bunker.scl3.mozilla.com:9200/ http://node49.bunker.scl3.mozilla.com:9200/
 es_catalog_replicas = 4
@@ -17,7 +17,6 @@ es_refresh_interval = 30
 source_folder = src/mozilla-central
 object_folder = obj/mozilla-central
 es_index = dxr_hot_{format}_{tree}_{unique}
-disabled_plugins =  
 ignore_patterns = all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder && ./mach mercurial-setup -u && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"
   [[xpidl]]
@@ -32,7 +31,6 @@ build_command = cd $source_folder && ./mach mercurial-setup -u && ./mach clobber
 [mozilla-aurora]
 source_folder = src/releases/mozilla-aurora
 object_folder = obj/releases/mozilla-aurora
-disabled_plugins =  
 ignore_patterns = all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder && ./mach mercurial-setup -u && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"
   [[xpidl]]
@@ -47,6 +45,7 @@ build_command = cd $source_folder && ./mach mercurial-setup -u && ./mach clobber
 [mozilla-beta]
 source_folder = src/releases/mozilla-beta
 object_folder = obj/releases/mozilla-beta
+disabled_plugins = xpidl
 ignore_patterns = all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"
   [[xpidl]]
@@ -61,6 +60,7 @@ build_command = cd $source_folder && ./mach clobber && make -f client.mk build M
 [mozilla-release]
 source_folder = src/releases/mozilla-release
 object_folder = obj/releases/mozilla-release
+disabled_plugins = xpidl
 ignore_patterns = all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"
   [[xpidl]]
@@ -75,6 +75,7 @@ build_command = cd $source_folder && ./mach clobber && make -f client.mk build M
 [mozilla-esr45]
 source_folder = src/releases/mozilla-esr45
 object_folder = obj/releases/mozilla-esr45
+disabled_plugins = xpidl
 ignore_patterns = all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder && ./mach clobber && make -f client.mk build MOZ_MAKE_FLAGS="-s -j{workers}"
   [[xpidl]]
@@ -90,6 +91,7 @@ build_command = cd $source_folder && ./mach clobber && make -f client.mk build M
 source_folder = src/comm-central
 object_folder = obj/comm-central
 es_index = dxr_hot_{format}_{tree}_{unique}
+disabled_plugins = xpidl
 ignore_patterns = all-tests.json .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder && python client.py checkout && ./mozilla/mach mercurial-setup -u && ./mozilla/mach clobber && ./mozilla/mach build
   [[python]]
@@ -101,6 +103,7 @@ build_command = cd $source_folder && python client.py checkout && ./mozilla/mach
 [build-central]
 source_folder = src/build
 object_folder = obj/build
+disabled_plugins = xpidl
 ignore_patterns = *.svg .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = 
   [[python]]
@@ -112,6 +115,7 @@ build_command =
 [hgcustom_version-control-tools]
 source_folder = src/hgcustom/version-control-tools
 object_folder = obj/hgcustom/version-control-tools
+disabled_plugins = xpidl
 build_command = 
   [[python]]
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
@@ -123,6 +127,7 @@ build_command =
 source_folder = src/rust-lang/rust
 object_folder = obj/rust-lang/rust
 es_index = dxr_hot_{format}_{tree}_{unique}
+disabled_plugins = xpidl
 ignore_patterns = /compiletest/ /doc/ /etc/ /gyp/ .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder && ./configure --disable-libcpp --enable-ccache --enable-clang && make clean && make -j4
   [[buglink]]
@@ -135,6 +140,7 @@ build_command = cd $source_folder && ./configure --disable-libcpp --enable-ccach
 [rustfmt]
 source_folder = src/rustfmt
 object_folder = obj/rustfmt
+disabled_plugins = xpidl
 ignore_patterns = /target/ /tests/ /data/ .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder/src && RUSTC=/builds/dxr-build-env/dxr/dxr/plugins/rust/dxr-rustc.sh cargo build --verbose
   [[buglink]]
@@ -147,6 +153,7 @@ build_command = cd $source_folder/src && RUSTC=/builds/dxr-build-env/dxr/dxr/plu
 [nss]
 source_folder = src/nss
 object_folder = obj/nss
+disabled_plugins = xpidl
 build_command = cd $source_folder/nss && env CPATH=/usr/include/x86_64-linux-gnu make NS_USE_GCC=0 CC=clang CXX=clang++ USE_64=1 NSS_DISABLE_GTESTS=1 nss_build_all
   [[python]]
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages


### PR DESCRIPTION
Well, it's been a long road to proper config. Turns out clearing
disabled_plugins is not possible in tree config because the total
disabled_plugins is the concatenation of global+tree disables.
