### PR TITLE
Stop building nss and rust

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -188,7 +188,7 @@ trees:
       - url: 'https://hg.mozilla.org/hgcustom/version-control-tools'
 
   - name: 'rust'
-    disabled_plugins: 'xpidl'
+    disabled_plugins: 'xpidl clang rust'
     proj_dir: 'rust-lang'
     repos:
       - url: 'https://github.com/rust-lang/rust.git'
@@ -198,7 +198,6 @@ trees:
     es_index: 'dxr_hot_{format}_{tree}_{unique}'
     enabled_plugins: 'pygmentize rust buglink omniglot'
     ignore_patterns: '/compiletest/ /doc/ /etc/ /gyp/ .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc'
-    build_command: 'cd $source_folder && ./configure --disable-libcpp --enable-ccache --enable-clang && make clean && make -j4'
     plugins:
       - plugin: 'buglink'
         name: 'github'
@@ -219,13 +218,12 @@ trees:
         regex: '#([0-9]+)'
 
   - name: 'nss'
-    disabled_plugins: 'xpidl'
+    disabled_plugins: 'xpidl clang'
     proj_dir: 'nss'
     repos:
       - url: 'https://hg.mozilla.org/projects/nss'
       - url: 'https://hg.mozilla.org/projects/nspr'
     job_weight: 2
-    build_command: 'cd $source_folder/nss && env CPATH=/usr/include/x86_64-linux-gnu make NS_USE_GCC=0 CC=clang CXX=clang++ USE_64=1 NSS_DISABLE_GTESTS=1 nss_build_all'
 
   - name: 'gaia'
     disabled_plugins: 'xpidl'

--- a/dxr.config
+++ b/dxr.config
@@ -127,9 +127,9 @@ build_command =
 source_folder = src/rust-lang/rust
 object_folder = obj/rust-lang/rust
 es_index = dxr_hot_{format}_{tree}_{unique}
-disabled_plugins = xpidl
+disabled_plugins = xpidl clang rust
 ignore_patterns = /compiletest/ /doc/ /etc/ /gyp/ .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
-build_command = cd $source_folder && ./configure --disable-libcpp --enable-ccache --enable-clang && make clean && make -j4
+build_command = 
   [[buglink]]
     url = https://github.com/rust-lang/rust/issues/%s
     regex = #([0-9]+)
@@ -153,8 +153,8 @@ build_command = cd $source_folder/src && RUSTC=/builds/dxr-build-env/dxr/dxr/plu
 [nss]
 source_folder = src/nss
 object_folder = obj/nss
-disabled_plugins = xpidl
-build_command = cd $source_folder/nss && env CPATH=/usr/include/x86_64-linux-gnu make NS_USE_GCC=0 CC=clang CXX=clang++ USE_64=1 NSS_DISABLE_GTESTS=1 nss_build_all
+disabled_plugins = xpidl clang
+build_command = 
   [[python]]
     python_path = /builds/dxr-build-env/venv/lib/python2.7/site-packages
   [[buglink]]


### PR DESCRIPTION
These repos have not been building for at least a month, so this commit stops building and running the clang and rust plugins for them.

Aside from that, build-central last failed with a StringOutOfBounds error (on checkout?), and rustfmt hit an intermittent connection timeout error (which upping retry count had not fixed, apparently).
