### PR TITLE
Disable rust building

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -188,7 +188,7 @@ trees:
       - url: 'https://hg.mozilla.org/hgcustom/version-control-tools'
 
   - name: 'rust'
-    disabled_plugins: 'xpidl'
+    disabled_plugins: 'xpidl clang rust'
     proj_dir: 'rust-lang'
     repos:
       - url: 'https://github.com/rust-lang/rust.git'
@@ -198,7 +198,6 @@ trees:
     es_index: 'dxr_hot_{format}_{tree}_{unique}'
     enabled_plugins: 'pygmentize rust buglink omniglot'
     ignore_patterns: '/compiletest/ /doc/ /etc/ /gyp/ .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc'
-    build_command: 'cd $source_folder && ./configure --disable-libcpp --enable-ccache --enable-clang && make clean && make -j4'
     plugins:
       - plugin: 'buglink'
         name: 'github'

--- a/dxr.config
+++ b/dxr.config
@@ -127,9 +127,9 @@ build_command =
 source_folder = src/rust-lang/rust
 object_folder = obj/rust-lang/rust
 es_index = dxr_hot_{format}_{tree}_{unique}
-disabled_plugins = xpidl
+disabled_plugins = xpidl clang rust
 ignore_patterns = /compiletest/ /doc/ /etc/ /gyp/ .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
-build_command = cd $source_folder && ./configure --disable-libcpp --enable-ccache --enable-clang && make clean && make -j4
+build_command = 
   [[buglink]]
     url = https://github.com/rust-lang/rust/issues/%s
     regex = #([0-9]+)


### PR DESCRIPTION
https://jenkins-dxr.mozilla.org/job/rust/ has not built in a month, and currently seems to face a build error. We could disable the build for now so the new format could pass (my impression is that the other trees only failed because of intermittent connection timeouts).
