### PR TITLE
Add buglink to disabled_plugins of rustfmt

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -206,7 +206,7 @@ trees:
         regex: '#([0-9]+)'
 
   - name: 'rustfmt'
-    disabled_plugins: 'xpidl'
+    disabled_plugins: 'xpidl buglink'
     repos:
       - url: 'https://github.com/rust-lang-nursery/rustfmt.git'
     enabled_plugins: 'pygmentize rust buglink'

--- a/dxr.config
+++ b/dxr.config
@@ -140,7 +140,7 @@ build_command = cd $source_folder && ./configure --disable-libcpp --enable-ccach
 [rustfmt]
 source_folder = src/rustfmt
 object_folder = obj/rustfmt
-disabled_plugins = xpidl
+disabled_plugins = xpidl buglink
 ignore_patterns = /target/ /tests/ /data/ .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = cd $source_folder/src && RUSTC=/builds/dxr-build-env/dxr/dxr/plugins/rust/dxr-rustc.sh cargo build --verbose
   [[buglink]]


### PR DESCRIPTION
https://jenkins-dxr.mozilla.org/job/rustfmt/lastFailedBuild/console

```
16:57:47 A worker failed while indexing /builds/dxr-build-env/src/rustfmt/.cargo/registry/index/github.com-88ac128001ac3a9a/ru/st/rust-xmlrpc:
16:57:47 Traceback (most recent call last):
16:57:47   File "/builds/dxr-build-env/dxr/dxr/plugins/buglink/__init__.py", line 15, in refs
16:57:47     bug = m.group(1)
16:57:47 IndexError: no such group
```
