### PR TITLE
Disable buglink on rust tree as well.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -188,7 +188,7 @@ trees:
       - url: 'https://hg.mozilla.org/hgcustom/version-control-tools'
 
   - name: 'rust'
-    disabled_plugins: 'xpidl clang rust'
+    disabled_plugins: 'xpidl clang rust buglink'
     proj_dir: 'rust-lang'
     repos:
       - url: 'https://github.com/rust-lang/rust.git'

--- a/dxr.config
+++ b/dxr.config
@@ -127,7 +127,7 @@ build_command =
 source_folder = src/rust-lang/rust
 object_folder = obj/rust-lang/rust
 es_index = dxr_hot_{format}_{tree}_{unique}
-disabled_plugins = xpidl clang rust
+disabled_plugins = xpidl clang rust buglink
 ignore_patterns = /compiletest/ /doc/ /etc/ /gyp/ .hg .git CVS .svn .bzr .deps .libs .DS_Store .nfs* *~ ._* *.pyc
 build_command = 
   [[buglink]]


### PR DESCRIPTION
Seems the same issue on rustfmt happens on rust too, so here I add buglink to the list of disabled plugins.

https://jenkins-dxr.mozilla.org/job/rust/lastBuild/

This is likely a bug in DXR since I see no reason the supplied regex could match but not have a group to extract. I'll remind myself to file in the morning.
