### PR TITLE
Add Okta authentication for /addons tree

### DIFF
--- a/ansible/roles/web/tasks/main.yml
+++ b/ansible/roles/web/tasks/main.yml
@@ -25,6 +25,9 @@
 - name: install hostname.conf
   copy: content="Header always set X-Backend-Server {{ ansible_fqdn }}" dest=/etc/httpd/conf.d/hostname.conf
 
+- name: create mellon directory
+  file: path=/etc/httpd/mellon state=directory owner=root group=apache mode=0750
+
 - name: make logdir
   file: path=/var/log/httpd/{{ domain }} state=directory owner=apache group=vpn_dxr mode=0755
 

--- a/ansible/roles/web/tasks/main.yml
+++ b/ansible/roles/web/tasks/main.yml
@@ -11,6 +11,7 @@
     - python27-mod_wsgi
     - logrotate
     - httpd
+    - mod_auth_mellon
 
 - name: install httpd.conf file
   template: src=httpd.conf.j2 dest=/etc/httpd/conf/httpd.conf

--- a/ansible/roles/web/templates/vhost.conf.j2
+++ b/ansible/roles/web/templates/vhost.conf.j2
@@ -11,7 +11,7 @@ SetEnvIf Remote_Addr "127\.0\.0\.1" dontlog
 SetEnvIf Remote_Addr "::1" dontlog
 
 <VirtualHost *:80>
-  ServerName {{ domain }}
+  ServerName https://{{ domain }}
   CustomLog /var/log/httpd/{{ domain }}/access_log proxy env=!dontlog
   ErrorLog /var/log/httpd/{{ domain }}/error_log
 

--- a/ansible/roles/web/templates/vhost.conf.j2
+++ b/ansible/roles/web/templates/vhost.conf.j2
@@ -33,5 +33,47 @@ SetEnvIf Remote_Addr "::1" dontlog
     Order allow,deny
     Allow from all
   </Directory>
+
+  # Configure an SSO application at the $APPURL provided when generating the metadata XML
+  <Location /addons>
+    # The endpoint provided when generating the metadata XML
+    MellonEndpointPath /addons/mellon
+
+    # The generated private key, certificate, and metadata XML files
+    MellonSPPrivateKeyFile /etc/httpd/mellon/{{ domain }}_addons.key
+    MellonSPCertFile /etc/httpd/mellon/{{ domain }}_addons.cert
+    MellonSPMetadataFile /etc/httpd/mellon/{{ domain }}_addons.xml
+
+    # The IdP metadata XML binds this app to our SSO IdP (Okta)
+    MellonIdPMetadataFile /etc/httpd/mellon/{{ domain }}_addons.idp-metadata.xml
+
+    MellonSecureCookie On
+    MellonSubjectConfirmationDataAddressCheck Off
+  </Location>
+
+  # This public, unrestricted endpoint is necessary for SAML communication with Mellon
+  <Location /addons/mellon>
+    # We do NOT specify MellonEnable "none" here, because we need Mellon to process
+    # requests to this endpoint.
+
+    # Disable authentication for this endpoint
+    AuthType none
+
+    # Allow all requests to this endpoint
+    Order allow,deny
+    Allow from all
+    Satisfy any
+  </Location>
+
+  <Location /addons>
+    # Mellon will intercept requests that do not provide a non-expired session
+    # cookie and redirect them momentarily to Okta.
+    MellonEnable "auth"
+    AuthType Mellon
+    # Ensure that we authenticated a valid user through Okta and Mellon. This provides
+    # a layer of defense against unplanned issues.
+    require valid-user
+  </Location>
+
 </VirtualHost>
 


### PR DESCRIPTION
This will install (or ensure) the package(s) and Apache config for Okta/Mellon authentication, so that we can index the addons tree.
