### PR TITLE
Disable js plugin on addons tree.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -646,7 +646,7 @@ trees:
 
   - name: 'addons'
     type: 'tree'
-    disabled_plugins: 'xpidl buglink clang extmatch rust python'
+    disabled_plugins: 'xpidl buglink clang extmatch rust python js'
     job_weight: 4
     es_shards: 40
     repos:


### PR DESCRIPTION
This way, it won't run out of disk space for its temp files, but people can still have about as much functionality as MXR provided.
