### PR TITLE
Fix OpenIDC shim for HTTP headers too large error

### DIFF
--- a/ansible/roles/jenkins-master/defaults/main.yml
+++ b/ansible/roles/jenkins-master/defaults/main.yml
@@ -2,7 +2,6 @@
 worker_processes: "{{ ansible_processor_cores }}"
 openresty_repo_url: https://openresty.org/yum/rhel-6/OpenResty.repo
 openresty_repo_key_url: https://copr-be.cloud.fedoraproject.org/results/openresty/openresty/pubkey.gpg
-openidc_layer_shim_url: https://raw.githubusercontent.com/mozilla-iam/testrp.security.allizom.org/master/webserver_configurations/OpenID_Connect/Nginx/conf.d/openidc_layer.lua
 lua_resty_openidc_url: https://raw.githubusercontent.com/pingidentity/lua-resty-openidc/master/lib/resty/openidc.lua
 jenkins_repo_url: https://pkg.jenkins.io/redhat/jenkins.repo
 jenkins_repo_key_url: https://pkg.jenkins.io/redhat/jenkins-ci.org.key

--- a/ansible/roles/jenkins-master/files/openidc_layer.lua
+++ b/ansible/roles/jenkins-master/files/openidc_layer.lua
@@ -1,0 +1,60 @@
+-- Lua reference for nginx: https://github.com/openresty/lua-nginx-module
+-- Lua reference for openidc: https://github.com/pingidentity/lua-resty-openidc
+local oidc = require("resty.openidc")
+local cjson = require( "cjson" )
+
+-- Load config
+local f, e = loadfile(ngx.var.config_loader)
+if f == nil then
+  ngx.log(ngx.ERR, "can't initialize loadfile: "..e)
+end
+ok, e = pcall(f)
+if not ok then
+  ngx.log(ngx.ERR, "can't load configuration: "..e)
+end
+
+-- Authenticate with lua-resty-openidc if necessary (this will return quickly if no authentication is necessary)
+local res, err, url, session = oidc.authenticate(opts)
+
+-- Check if authentication succeeded, otherwise kick the user out
+if err then
+  if session ~= nil then
+    session:destroy()
+  end
+  ngx.redirect(opts.logout_path)
+else
+  ngx.log(ngx.ERR, "no error was returned but session is not set. A possible cause is that you're using lua-resty-openidc 1.3.1 or earlier which do not have the required features. If lua-resty-openidc 1.3.2 or newer is available, please upgrade. If lua-resty-openidc 1.3.2 has not yet been released, you can find the needed functionality in https://github.com/pingidentity/lua-resty-openidc/commit/7bafac883264ac4d33a8a83da7040a74024ca08f or newer.")
+end
+
+-- Access control: only allow specific users in (this is optional, without it all authenticated users are allowed in)
+-- (TODO: add example)
+
+-- Set headers with user info and OIDC claims for the underlaying web application to use (this is optional)
+-- These header names are voluntarily similar to Apaches mod_auth_openidc, but may of course be modified
+ngx.req.set_header("REMOTE_USER", session.data.user.email)
+ngx.req.set_header("X-Forwarded-User", session.data.user.email)
+ngx.req.set_header("OIDC_CLAIM_ACCESS_TOKEN", session.data.access_token)
+ngx.req.set_header("OIDC_CLAIM_ID_TOKEN", session.data.enc_id_token)
+ngx.req.set_header("via",session.data.user.email)
+
+-- local function build_headers(t, name)
+--   for k,v in pairs(t) do
+--     -- unpack tables
+--     if type(v) == "table" then
+--       local j = cjson.encode(v)
+--       ngx.req.set_header("OIDC_CLAIM_"..name..k, j)
+--     else
+--       ngx.req.set_header("OIDC_CLAIM_"..name..k, tostring(v))
+--     end
+--   end
+-- end
+-- 
+-- build_headers(session.data.id_token, "ID_TOKEN_")
+-- build_headers(session.data.user, "USER_PROFILE_")
+
+-- Flat groups, useful for some RP's that won't read JSON
+local gprs = ""
+for k,v in pairs(session.data.user.groups) do
+  grps = grps and grps.."|"..v or v
+end
+ngx.req.set_header("X-Forwarded-Groups", grps)

--- a/ansible/roles/jenkins-master/tasks/main.yml
+++ b/ansible/roles/jenkins-master/tasks/main.yml
@@ -48,8 +48,8 @@
   notify: restart openresty
 
 - name: install openidc_layer shim
-  get_url: url="{{ openidc_layer_shim_url }}"
-           dest=/usr/local/openresty/nginx/conf/
+  copy: src=openidc_layer.lua
+        dest=/usr/local/openresty/nginx/conf/openidc_layer.lua
   notify: restart openresty
 
 - name: install nginx.conf file


### PR DESCRIPTION
Auth0 sends information back to the OpenIDC shim which gets converted to
HTTP headers and sent to Jenkins. A recent change increased the amount
of data sent, which in turn caused the amount of HTTP headers to exceed
the hardcoded limit in Jenkins. So we stop using the default shim
offered by EIS and use a local copy that trims down the headers.